### PR TITLE
feat: Initial setup of MCP Server application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.1.18.RELEASE</version> <!-- Compatible with Java 8 -->
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>mcp-server</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>mcp-server</name>
+    <description>MCP Server for Freight Document ETA</description>
+
+    <properties>
+        <java.version>1.8</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/mcpserver/McpServerApplication.java
+++ b/src/main/java/com/example/mcpserver/McpServerApplication.java
@@ -1,0 +1,13 @@
+package com.example.mcpserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class McpServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(McpServerApplication.class, args);
+    }
+
+}

--- a/src/main/java/com/example/mcpserver/advice/RestExceptionHandler.java
+++ b/src/main/java/com/example/mcpserver/advice/RestExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.example.mcpserver.advice;
+
+import com.example.mcpserver.service.DocumentNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(DocumentNotFoundException.class)
+    protected ResponseEntity<Object> handleDocumentNotFound(
+            DocumentNotFoundException ex, WebRequest request) {
+        // You can create a custom error response object if needed
+        ApiError apiError = new ApiError(HttpStatus.NOT_FOUND, ex.getLocalizedMessage(), "Document not found");
+        return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
+    }
+
+    // Inner class for structured error response
+    private static class ApiError {
+        private HttpStatus status;
+        private String message;
+        private String error;
+
+        public ApiError(HttpStatus status, String message, String error) {
+            super();
+            this.status = status;
+            this.message = message;
+            this.error = error;
+        }
+
+        // Getters for serialization
+        public HttpStatus getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getError() {
+            return error;
+        }
+    }
+}

--- a/src/main/java/com/example/mcpserver/controller/FreightController.java
+++ b/src/main/java/com/example/mcpserver/controller/FreightController.java
@@ -1,0 +1,33 @@
+package com.example.mcpserver.controller;
+
+import com.example.mcpserver.service.FreightService;
+// Import DocumentNotFoundException from the service package
+import com.example.mcpserver.service.DocumentNotFoundException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/freight")
+public class FreightController {
+
+    private final FreightService freightService;
+
+    @Autowired
+    public FreightController(FreightService freightService) {
+        this.freightService = freightService;
+    }
+
+    @GetMapping("/{documentNumber}/eta")
+    public ResponseEntity<LocalDateTime> getEstimatedArrivalTime(@PathVariable String documentNumber) {
+        LocalDateTime eta = freightService.getEstimatedArrivalTime(documentNumber);
+        return ResponseEntity.ok(eta);
+    }
+}

--- a/src/main/java/com/example/mcpserver/model/FreightDocument.java
+++ b/src/main/java/com/example/mcpserver/model/FreightDocument.java
@@ -1,0 +1,62 @@
+package com.example.mcpserver.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+public class FreightDocument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String documentNumber;
+
+    private LocalDateTime estimatedArrivalTime;
+
+    // Constructors
+    public FreightDocument() {
+    }
+
+    public FreightDocument(String documentNumber, LocalDateTime estimatedArrivalTime) {
+        this.documentNumber = documentNumber;
+        this.estimatedArrivalTime = estimatedArrivalTime;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDocumentNumber() {
+        return documentNumber;
+    }
+
+    public void setDocumentNumber(String documentNumber) {
+        this.documentNumber = documentNumber;
+    }
+
+    public LocalDateTime getEstimatedArrivalTime() {
+        return estimatedArrivalTime;
+    }
+
+    public void setEstimatedArrivalTime(LocalDateTime estimatedArrivalTime) {
+        this.estimatedArrivalTime = estimatedArrivalTime;
+    }
+
+    @Override
+    public String toString() {
+        return "FreightDocument{" +
+                "id=" + id +
+                ", documentNumber='" + documentNumber + '\'' +
+                ", estimatedArrivalTime=" + estimatedArrivalTime +
+                '}';
+    }
+}

--- a/src/main/java/com/example/mcpserver/repository/FreightDocumentRepository.java
+++ b/src/main/java/com/example/mcpserver/repository/FreightDocumentRepository.java
@@ -1,0 +1,14 @@
+package com.example.mcpserver.repository;
+
+import com.example.mcpserver.model.FreightDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FreightDocumentRepository extends JpaRepository<FreightDocument, Long> {
+
+    Optional<FreightDocument> findByDocumentNumber(String documentNumber);
+
+}

--- a/src/main/java/com/example/mcpserver/service/FreightService.java
+++ b/src/main/java/com/example/mcpserver/service/FreightService.java
@@ -1,0 +1,43 @@
+package com.example.mcpserver.service;
+
+import com.example.mcpserver.model.FreightDocument;
+import com.example.mcpserver.repository.FreightDocumentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+// Define a custom exception for document not found
+class DocumentNotFoundException extends RuntimeException {
+    public DocumentNotFoundException(String message) {
+        super(message);
+    }
+}
+
+@Service
+public class FreightService {
+
+    private final FreightDocumentRepository freightDocumentRepository;
+
+    @Autowired
+    public FreightService(FreightDocumentRepository freightDocumentRepository) {
+        this.freightDocumentRepository = freightDocumentRepository;
+    }
+
+    public LocalDateTime getEstimatedArrivalTime(String documentNumber) {
+        Optional<FreightDocument> documentOptional = freightDocumentRepository.findByDocumentNumber(documentNumber);
+
+        if (documentOptional.isPresent()) {
+            return documentOptional.get().getEstimatedArrivalTime();
+        } else {
+            // Later, this can be handled by a @ControllerAdvice for a 404 response
+            throw new DocumentNotFoundException("Freight document with number '" + documentNumber + "' not found.");
+        }
+    }
+
+    // Optional: Method to add a new document (useful for testing)
+    public FreightDocument saveDocument(FreightDocument document) {
+        return freightDocumentRepository.save(document);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+spring.application.name=mcp-server
+
+# H2 Database Configuration
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:mem:mcpdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# Show SQL statements for debugging (optional, can be noisy)
+# spring.jpa.show-sql=true
+# Defer JPA initialization to allow H2 console to be available
+spring.jpa.defer-datasource-initialization=true


### PR DESCRIPTION
This commit includes the initial structure and core components for the MCP Server.

Changes include:
- Initialized a Spring Boot project (Java 1.8) with Maven, Spring Web, Spring Data JPA, and H2.
- Defined the `FreightDocument` JPA entity.
- Created `FreightDocumentRepository` for database operations.
- Implemented `FreightService` containing business logic to fetch ETA and handle `DocumentNotFoundException`.
- Created `FreightController` to expose the `/api/freight/{documentNumber}/eta` REST endpoint.
- Set up the main `McpServerApplication` class.
- Configured `application.properties` for H2 console and datasource.
- Added a global `RestExceptionHandler` using `@ControllerAdvice` for centralized error handling.

Next steps involve writing unit tests for the service and controller layers.